### PR TITLE
Implement Error Trait

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,6 @@
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
 #[derive(Debug)]
 pub enum ProcMemError {
     /// Could not take a snapshot of the processes/modules
@@ -23,3 +26,28 @@ pub enum ProcMemError {
     /// Could not read the found address and add it to the result
     RIPRelativeFailed,
 }
+
+impl Display for ProcMemError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match &self {
+                Self::CreateSnapshotFailure => "could not take a snapshot of the processes/modules",
+                Self::IterateSnapshotFailure => "could not iterate over the snapshot entries",
+                Self::ProcessNotFound => "process was not found in the snapshot of the processes",
+                Self::ModuleNotFound => "module was not found in the snapshot of the modules",
+                Self::GetHandleError => "could not get a HANDLE to read/write the process memory",
+                Self::TerminateProcessError => "could not terminate the process",
+                Self::ReadMemoryError => "could not read the process memory",
+                Self::WriteMemoryError => "could not write to the process memory",
+                Self::SignatureNotFound => "could not find the provided signature in the module",
+                Self::AddressOutOfBounds => "signature pattern has lead out of bounds",
+                Self::RIPRelativeFailed =>
+                    "could not read the found address and add it to the result",
+            }
+        )
+    }
+}
+
+impl Error for ProcMemError {}


### PR DESCRIPTION
Implement the std::error::Error (and therefore std::fmt::Display) trait for ProcMemError to make it compatible with the broader ecosystem, e.g. the anyhow crate

This could be done in a slightly more readable/idiomatic way with the thiserror crate if preferred, but I figured it was better to not introduce any more dependencies since this error type is pretty simple 